### PR TITLE
Fixed syntax for variable calls in Qt-Pro files

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -10,4 +10,4 @@ CONFIG -= app_bundle
 
 SOURCES += source/main.cpp
 
-LIBS += -L../src -l$APP_NAME
+LIBS += -L../src -l$${APP_NAME}

--- a/src/src.pro
+++ b/src/src.pro
@@ -3,10 +3,10 @@ QT       += core gui sql
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
 win32 {
-  TARGET = ../$APP_NAME
+  TARGET = ../$${APP_NAME}
 }
 unix {
-  TARGET = $APP_NAME
+  TARGET = $${APP_NAME}
 }
 CONFIG -= testlib
 TEMPLATE = lib

--- a/test/test.pro
+++ b/test/test.pro
@@ -10,7 +10,7 @@ CONFIG +=console
 CONFIG += app_bundle
 INCLUDEPATH += .
 
-LIBS += -L../src -l$APP_NAME
+LIBS += -L../src -l$${APP_NAME}
 
 SOURCES += \
     test_main.cpp


### PR DESCRIPTION
Syntax for PRO fiel variables is $${VAR_NAME} 
... because
